### PR TITLE
Latest libmpd and hint package supported and more changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,177 @@
+sudo: false
+language: c
+cache:
+  directories:
+  - "$HOME/.ghc"
+  - "$HOME/.cabal"
+  - "$HOME/.stack"
+matrix:
+  include:
+  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=
+    compiler: ": #GHC 7.8.4"
+    addons:
+      apt:
+        packages:
+        - cabal-install-1.18
+        - ghc-7.8.4
+        - happy-1.19.5
+        - alex-3.1.7
+        sources:
+        - hvr-ghc
+  - env: BUILD=stack ARGS="--resolver lts-2.22"
+    compiler: ": #stack 7.8.4"
+    addons:
+      apt:
+        packages:
+        - libgmp-dev
+  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
+    compiler: ": #GHC 7.10.3"
+    addons:
+      apt:
+        packages:
+        - cabal-install-1.22
+        - ghc-7.10.3
+        - happy-1.19.5
+        - alex-3.1.7
+        sources:
+        - hvr-ghc
+  - env: BUILD=stack ARGS="--resolver lts-6"
+    compiler: ": #stack 7.10.3"
+    addons:
+      apt:
+        packages:
+        - libgmp-dev
+  - env: BUILD=stack ARGS="--resolver lts-6"
+    compiler: ": #stack 7.10.3 osx"
+    os: osx
+  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
+    compiler: ": #GHC 8.0.2"
+    addons:
+      apt:
+        packages:
+        - cabal-install-1.24
+        - ghc-8.0.2
+        - happy-1.19.5
+        - alex-3.1.7
+        sources:
+        - hvr-ghc
+  - env: BUILD=stack ARGS="--resolver lts-8.3"
+    compiler: ": #stack 8.0.2"
+    addons:
+      apt:
+        packages:
+        - libgmp-dev
+  - env: BUILD=stack ARGS="--resolver lts-8.3"
+    compiler: ": #stack 8.0.2 osx"
+    os: osx
+  - env: BUILD=stack ARGS=""
+    compiler: ": #stack default"
+    addons:
+      apt:
+        packages:
+        - libgmp-dev
+  - env: BUILD=stack ARGS=""
+    compiler: ": #stack default osx"
+    os: osx
+  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
+    compiler: ": #GHC HEAD"
+    addons:
+      apt:
+        packages:
+        - cabal-install-head
+        - ghc-head
+        - happy-1.19.5
+        - alex-3.1.7
+        sources:
+        - hvr-ghc
+  - env: BUILD=stack ARGS="--resolver nightly"
+    compiler: ": #stack nightly"
+    addons:
+      apt:
+        packages:
+        - libgmp-dev
+  - env: BUILD=stack ARGS="--resolver nightly"
+    compiler: ": #stack nightly osx"
+    os: osx
+  allow_failures:
+  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
+  - env: BUILD=stack ARGS="--resolver nightly"
+
+before_install:
+# Using compiler above sets CC to an invalid value, so unset it
+- unset CC
+
+# We want to always allow newer versions of packages when building on GHC HEAD
+- CABALARGS=""
+- if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
+
+# Download and unpack the stack executable
+- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
+- mkdir -p ~/.local/bin
+- |
+  if [ `uname` = "Darwin" ]
+  then
+    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  else
+    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  fi
+
+  # Use the more reliable S3 mirror of Hackage
+  mkdir -p $HOME/.cabal
+  echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
+  echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
+
+  if [ "$CABALVER" != "1.16" ]
+  then
+    echo 'jobs: $ncpus' >> $HOME/.cabal/config
+  fi
+
+install:
+- echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+- if [ -f configure.ac ]; then autoreconf -i; fi
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+      ;;
+    cabal)
+      cabal --version
+      travis_retry cabal update
+
+      # Get the list of packages from the stack.yaml file
+      PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
+
+      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      ;;
+  esac
+  set +ex
+
+script:
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal $ARGS test --bench --no-run-benchmarks
+      ;;
+    cabal)
+      cabal install --enable-tests $RUN_TESTS --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+
+      ORIGDIR=$(pwd)
+      for dir in $PACKAGES
+      do
+        cd $dir
+        cabal check || [ "$CABALVER" == "1.16" ]
+        cabal sdist
+        PKGVER=$(cabal info . | awk '{print $2;exit}')
+        SRC_TGZ=$PKGVER.tar.gz
+        cd dist
+        tar zxfv "$SRC_TGZ"
+        cd "$PKGVER"
+        cabal configure --enable-tests
+        cabal build
+        cd $ORIGDIR
+      done
+      ;;
+  esac
+  set +ex

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
         - alex-3.1.7
         - libasound2
         - libasound2-dev
+        - c2hs
         sources:
         - hvr-ghc
   - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
@@ -31,6 +32,7 @@ matrix:
         - alex-3.1.7
         - libasound2
         - libasound2-dev
+        - c2hs
         sources:
         - hvr-ghc
   - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
@@ -44,6 +46,7 @@ matrix:
         - alex-3.1.7
         - libasound2
         - libasound2-dev
+        - c2hs
         sources:
         - hvr-ghc
   - env: BUILD=stack ARGS="--resolver lts-8.20"
@@ -54,6 +57,7 @@ matrix:
         - libgmp-dev
         - libasound2
         - libasound2-dev
+        - c2hs
   - env: BUILD=stack ARGS=""
     compiler: ": #stack default"
     addons:
@@ -62,6 +66,7 @@ matrix:
         - libgmp-dev
         - libasound2
         - libasound2-dev
+        - c2hs
   - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
     compiler: ": #GHC HEAD"
     addons:
@@ -73,6 +78,7 @@ matrix:
         - alex-3.1.7
         - libasound2
         - libasound2-dev
+        - c2hs
         sources:
         - hvr-ghc
   - env: BUILD=stack ARGS="--resolver nightly"
@@ -83,6 +89,7 @@ matrix:
         - libgmp-dev
         - libasound2
         - libasound2-dev
+        - c2hs
   allow_failures:
   - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
   - env: BUILD=stack ARGS="--resolver nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,10 @@ matrix:
         - ghc-7.8.4
         - happy-1.19.5
         - alex-3.1.7
+        - libasound2
+        - libasound2-dev
         sources:
         - hvr-ghc
-  - env: BUILD=stack ARGS="--resolver lts-2.22"
-    compiler: ": #stack 7.8.4"
-    addons:
-      apt:
-        packages:
-        - libgmp-dev
   - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
     compiler: ": #GHC 7.10.3"
     addons:
@@ -33,17 +29,10 @@ matrix:
         - ghc-7.10.3
         - happy-1.19.5
         - alex-3.1.7
+        - libasound2
+        - libasound2-dev
         sources:
         - hvr-ghc
-  - env: BUILD=stack ARGS="--resolver lts-6"
-    compiler: ": #stack 7.10.3"
-    addons:
-      apt:
-        packages:
-        - libgmp-dev
-  - env: BUILD=stack ARGS="--resolver lts-6"
-    compiler: ": #stack 7.10.3 osx"
-    os: osx
   - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
     compiler: ": #GHC 8.0.2"
     addons:
@@ -53,26 +42,26 @@ matrix:
         - ghc-8.0.2
         - happy-1.19.5
         - alex-3.1.7
+        - libasound2
+        - libasound2-dev
         sources:
         - hvr-ghc
-  - env: BUILD=stack ARGS="--resolver lts-8.3"
+  - env: BUILD=stack ARGS="--resolver lts-8.20"
     compiler: ": #stack 8.0.2"
     addons:
       apt:
         packages:
         - libgmp-dev
-  - env: BUILD=stack ARGS="--resolver lts-8.3"
-    compiler: ": #stack 8.0.2 osx"
-    os: osx
+        - libasound2
+        - libasound2-dev
   - env: BUILD=stack ARGS=""
     compiler: ": #stack default"
     addons:
       apt:
         packages:
         - libgmp-dev
-  - env: BUILD=stack ARGS=""
-    compiler: ": #stack default osx"
-    os: osx
+        - libasound2
+        - libasound2-dev
   - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
     compiler: ": #GHC HEAD"
     addons:
@@ -82,6 +71,8 @@ matrix:
         - ghc-head
         - happy-1.19.5
         - alex-3.1.7
+        - libasound2
+        - libasound2-dev
         sources:
         - hvr-ghc
   - env: BUILD=stack ARGS="--resolver nightly"
@@ -90,9 +81,8 @@ matrix:
       apt:
         packages:
         - libgmp-dev
-  - env: BUILD=stack ARGS="--resolver nightly"
-    compiler: ": #stack nightly osx"
-    os: osx
+        - libasound2
+        - libasound2-dev
   allow_failures:
   - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7 RUN_TESTS=--run-tests
   - env: BUILD=stack ARGS="--resolver nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,7 +158,6 @@ script:
       for dir in $PACKAGES
       do
         cd $dir
-        cabal check || [ "$CABALVER" == "1.16" ]
         cabal sdist
         PKGVER=$(cabal info . | awk '{print $2;exit}')
         SRC_TGZ=$PKGVER.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+xmonad-extras
+---------------
+
+[![Build Status](https://travis-ci.org/xmonad/xmonad-extras.svg?branch=master)](https://travis-ci.org/xmonad/xmonad-extras)
+
+Third party extensions for xmonad with wacky dependencies

--- a/XMonad/Actions/Volume.hs
+++ b/XMonad/Actions/Volume.hs
@@ -58,6 +58,9 @@ import Control.Monad.Trans
 import Data.Maybe
 import XMonad.Core
 import Sound.ALSA.Mixer
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*>))
+#endif
 
 {- $usage
 You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:

--- a/XMonad/Prompt/MPD.hs
+++ b/XMonad/Prompt/MPD.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -25,7 +27,6 @@ module XMonad.Prompt.MPD (-- * Usage
                          ,findOrAdd
                          )  where
 import Control.Monad
-import qualified Data.ByteString as B
 import Data.Char
 import qualified Data.Map as M
 import Data.Maybe
@@ -100,7 +101,7 @@ extractSongs = mapMaybe extractSong
 -- returns the songs from that album.
 findMatching :: RunMPD -> XPConfig -> [Metadata] -> X [Song]
 findMatching runMPD xp metas = do
-  resp <- io . runMPD . fmap extractSongs . listAllInfo $ Path B.empty
+  resp <- io . runMPD . fmap extractSongs . listAllInfo $ ("" :: Path)
   case resp of
     Left err -> trace ("XMonad.Prompt.MPD: MPD returned an error: " ++ show err)
                 >> return []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-8.20
+
+extra-deps:
+- alsa-mixer-0.2.0.3
+- alsa-core-0.5.0.1
+- xmonad-extras-0.13.0

--- a/xmonad-extras.cabal
+++ b/xmonad-extras.cabal
@@ -63,12 +63,12 @@ library
         if impl(ghc < 7.2)
                 build-depends: hint >= 0.3 && < 0.4, network
         else
-                build-depends: hint >= 0.3.3.3 && < 0.5, network
+                build-depends: hint >= 0.3.3.3 && < 0.8, network
         exposed-modules: XMonad.Actions.Eval XMonad.Prompt.Eval
 --                         XMonad.Hooks.EvalServer
 
     if flag(with_mpd)
-        build-depends: libmpd >= 0.8 && < 0.9, bytestring >= 0.9 && < 0.11
+        build-depends: libmpd >= 0.9 && < 0.10, bytestring >= 0.9 && < 0.11
         exposed-modules: XMonad.Prompt.MPD
 
     if flag(with_regex_posix)

--- a/xmonad-extras.cabal
+++ b/xmonad-extras.cabal
@@ -8,7 +8,7 @@ category:           System
 license:            BSD3
 license-file:       LICENSE
 author:             The Daniels Schoepe and Wagner
-maintainer:         daniel@wagner-home.com, daniel.schoepe@googlemail.com
+maintainer:         Sibi <sibi@psibi.in>, daniel@wagner-home.com, daniel.schoepe@googlemail.com
 cabal-version:      >= 1.2.1
 build-type:         Simple
 

--- a/xmonad-extras.cabal
+++ b/xmonad-extras.cabal
@@ -1,6 +1,6 @@
 name:               xmonad-extras
 version:            0.13.0
-homepage:           http://projects.haskell.org/xmonad-extras
+homepage:           https://github.com/xmonad/xmonad-extras
 synopsis:           Third party extensions for xmonad with wacky dependencies
 description:        Various modules for xmonad that cannot be added to xmonad-contrib
                     because of additional dependencies.


### PR DESCRIPTION
General changs include testing via Travis CI server, Adding Stack
support, Support GHC version till 7.8.4 and relaxing cabal constraint
for libmpd and hint package so that cabal can pickup newer versions.