### PR TITLE
Update build-depends

### DIFF
--- a/xmonad-extras.cabal
+++ b/xmonad-extras.cabal
@@ -42,7 +42,7 @@ flag testing
 
 library
 
-    build-depends:      base < 5, mtl, containers, X11>=1.4.3, xmonad>=0.14 && <0.15, xmonad-contrib>=0.14 && <0.15
+    build-depends:      base < 5, mtl, containers, X11>=1.4.3, xmonad>=0.10 && <0.15, xmonad-contrib>=0.10 && <0.15
     ghc-options:        -fwarn-tabs -Wall -fno-warn-unused-do-bind
 
     -- Upload blocked by this: https://github.com/haskell/cabal/issues/2527

--- a/xmonad-extras.cabal
+++ b/xmonad-extras.cabal
@@ -42,7 +42,7 @@ flag testing
 
 library
 
-    build-depends:      base < 5, mtl, containers, X11>=1.4.3, xmonad>=0.10 && <0.14, xmonad-contrib>=0.10 && <0.14
+    build-depends:      base < 5, mtl, containers, X11>=1.4.3, xmonad>=0.14 && <0.15, xmonad-contrib>=0.14 && <0.15
     ghc-options:        -fwarn-tabs -Wall -fno-warn-unused-do-bind
 
     -- Upload blocked by this: https://github.com/haskell/cabal/issues/2527


### PR DESCRIPTION
Xmonad https://github.com/xmonad/xmonad/commit/55b14d48503aba4a0316d2b7290d5e4b5834f758 and Xmonad-contrib https://github.com/xmonad/xmonad-contrib/commit/065c305fed78057b2890b50df3d4658f5ddac5d2  just had their versions bumped.
I could not build using `stack` with `ghc-8.4.1` until i made these changes.

Im no xmonad expert not sure what else may need to change, but this change worked for me