### PR TITLE
update xmessage reference

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
             set -ex
             curl -sSL https://get.haskellstack.org/ | sh -s - -f
+            sudo apt update # why are png packages missing?
             sudo apt install -y libasound2t64 libasound2-dev libxrandr-dev libtinfo-dev
             sudo apt install -y libx11-dev libgmp-dev libxss-dev libxft-dev
             stack test --fast --no-terminal --resolver=${{ matrix.resolver }}

--- a/XMonad/Actions/Eval.hs
+++ b/XMonad/Actions/Eval.hs
@@ -29,6 +29,7 @@ import XMonad.Core
 import XMonad.Util.Run
 import Language.Haskell.Interpreter
 import Data.List
+import System.Environment
 
 -- $usage
 -- This module provides functions to evaluate haskell expressions at runtime
@@ -75,8 +76,9 @@ defaultEvalConfig = EvalConfig { handleError = handleErrorDefault
 
 -- | Default way to handle(in this case: display) an error during interpretation of an expression.
 handleErrorDefault :: InterpreterError -> X String
-handleErrorDefault err = io (safeSpawn "/usr/bin/xmessage" [replace (show err) "\\n" "\n"]) >>
-                         return "Error"
+handleErrorDefault err = do
+  xmsg <- fmap (maybe "xmessage" id) (io $ lookupEnv "XMONAD_XMESSAGE")
+  io (safeSpawn xmsg [replace (show err) "\\n" "\n"]) >> return "Error"
 
 -- | Returns an Interpreter action that loads the desired modules and interprets the expression.
 interpret' :: EvalConfig -> String -> Interpreter (X String)


### PR DESCRIPTION
xmonad these days doesn't use hardcoded `/usr/bin/xmessage`, it uses `$XMONAD_XMESSAGE` if defined and otherwise `PATH` search for `xmessage`.