### PR TITLE
`X.P.Eval` reexport `defaultEvalConfig`

### DIFF
--- a/XMonad/Prompt/Eval.hs
+++ b/XMonad/Prompt/Eval.hs
@@ -19,6 +19,7 @@ module XMonad.Prompt.Eval (
                            evalPrompt
                           ,evalPromptWithOutput
                           ,showWithDzen
+                          ,defaultEvalConfig
                           ) where
 
 import XMonad


### PR DESCRIPTION
It's in `X.A.Eval`, but the documentation doesn't tell you that you need to import it from there. And really, you shouldn't have to; it should be reexported.

(Yes, I know we've gone all `def`, but I still consider it a very bad idea especially after it caused breakage with the hide/show docks key.)